### PR TITLE
Add year support to products and filters

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,6 +44,12 @@
                     </select>
                 </div>
                 <div class="filter-group">
+                    <label for="anoFilter" class="filter-label">Ano</label>
+                    <select id="anoFilter" class="form-control">
+                        <option value="Todos">Todos</option>
+                    </select>
+                </div>
+                <div class="filter-group">
                     <label for="localizacaoFilter" class="filter-label">Localização</label>
                     <select id="localizacaoFilter" class="form-control">
                         <option value="Todos">Todos</option>
@@ -164,7 +170,7 @@
                         <thead>
                             <tr>
                                 <th>Tipo</th>
-                                <th>Mês</th>
+                                <th>Período</th>
                                 <th>Localização</th>
                                 <th>Produto Lider</th>
                                 <th>Concorrente</th>
@@ -216,11 +222,17 @@
                         </div>
                         <div class="form-row">
                             <div class="form-group">
+                                <label for="modalAno" class="form-label">Ano da Pesquisa *</label>
+                                <input type="number" id="modalAno" class="form-control" required min="2000" placeholder="2024">
+                            </div>
+                            <div class="form-group">
                                 <label for="modalLocalizacao" class="form-label">Localização *</label>
                                 <select id="modalLocalizacao" class="form-control" required>
                                     <option value="">Selecione...</option>
                                 </select>
                             </div>
+                        </div>
+                        <div class="form-row form-row--single">
                             <div class="form-group">
                                 <label for="modalPesquisador" class="form-label">Pesquisador *</label>
                                 <input type="text" id="modalPesquisador" class="form-control" required placeholder="Nome do pesquisador">

--- a/style.css
+++ b/style.css
@@ -1168,6 +1168,10 @@ select.form-control {
   margin-bottom: var(--space-16);
 }
 
+.form-row--single {
+  grid-template-columns: 1fr;
+}
+
 .form-row:last-child {
   margin-bottom: 0;
 }

--- a/test/getFilteredProducts.test.js
+++ b/test/getFilteredProducts.test.js
@@ -4,15 +4,20 @@ const {JSDOM} = require('jsdom');
 
 // Helper to load module with a given DOM
 function loadWithDOM(domHtml) {
-  const dom = new JSDOM(domHtml);
+  const dom = new JSDOM(domHtml, { url: 'http://localhost' });
+  dom.window.localStorage.clear();
+  global.window = dom.window;
   global.document = dom.window.document;
+  global.localStorage = dom.window.localStorage;
+  delete require.cache[require.resolve('../app.js')];
   return require('../app.js');
 }
 
-test('getFilteredProducts filters by type, month, and location', () => {
+test('getFilteredProducts filters by type, month, year, and location', () => {
   const { getFilteredProducts } = loadWithDOM(`<!DOCTYPE html>
     <select id="tipoFilter"><option value="Cadeira">Cadeira</option></select>
     <select id="mesFilter"><option value="Agosto">Agosto</option></select>
+    <select id="anoFilter"><option value="2023">2023</option></select>
     <select id="localizacaoFilter"><option value="Belo Horizonte">Belo Horizonte</option></select>`);
   const result = getFilteredProducts();
   assert.strictEqual(result.length, 1);
@@ -23,6 +28,7 @@ test('getFilteredProducts returns all items when filters are Todos', () => {
   const { getFilteredProducts, produtos } = loadWithDOM(`<!DOCTYPE html>
     <select id="tipoFilter"><option value="Todos">Todos</option></select>
     <select id="mesFilter"><option value="Todos">Todos</option></select>
+    <select id="anoFilter"><option value="Todos">Todos</option></select>
     <select id="localizacaoFilter"><option value="Todos">Todos</option></select>`);
   const result = getFilteredProducts();
   assert.strictEqual(result.length, produtos.length);
@@ -32,9 +38,21 @@ test('getFilteredProducts filters by competitor', () => {
   const { getFilteredProducts } = loadWithDOM(`<!DOCTYPE html>
     <select id="tipoFilter"><option value="Todos">Todos</option></select>
     <select id="mesFilter"><option value="Todos">Todos</option></select>
+    <select id="anoFilter"><option value="Todos">Todos</option></select>
     <select id="localizacaoFilter"><option value="Todos">Todos</option></select>
     <select id="concorrenteFilter"><option value="Herman Miller Aeron">Herman Miller Aeron</option></select>`);
   const result = getFilteredProducts();
   assert.strictEqual(result.length, 1);
   assert.strictEqual(result[0].concorrente.nome, 'Herman Miller Aeron');
+});
+
+test('getFilteredProducts filters by year independently', () => {
+  const { getFilteredProducts } = loadWithDOM(`<!DOCTYPE html>
+    <select id="tipoFilter"><option value="Todos">Todos</option></select>
+    <select id="mesFilter"><option value="Todos">Todos</option></select>
+    <select id="anoFilter"><option value="2023">2023</option></select>
+    <select id="localizacaoFilter"><option value="Todos">Todos</option></select>`);
+  const result = getFilteredProducts();
+  assert.strictEqual(result.length, 2);
+  assert.ok(result.every(produto => produto.ano === 2023));
 });


### PR DESCRIPTION
## Summary
- add an `ano` field to product data with normalization for existing storage entries and expose it in the filtering pipeline
- extend the dashboard UI to capture/select years, render combined "Mês de Ano" periods, and update export outputs
- cover the new year filter logic with updated unit tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68c9d4005b8c8321bae317bc2c20dbaf