### PR TITLE
Atualiza paleta solar e adiciona banner opcional no header

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,22 +10,26 @@
     <div class="dashboard">
         <!-- Header -->
         <header class="dashboard-header">
-            <div class="header-left">
-                <h1>Dashboard de Análise - Produtos</h1>
-                <span class="item-count" id="itemCount">3 ITENS</span>
+            <div class="dashboard-header__top">
+                <div class="header-left">
+                    <h1>Dashboard de Análise - Produtos</h1>
+                    <span class="item-count" id="itemCount">3 ITENS</span>
+                </div>
+                <div class="header-right">
+                    <button class="nav-btn" id="prevBtn" aria-label="Anterior">
+                        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <polyline points="15,18 9,12 15,6"></polyline>
+                        </svg>
+                    </button>
+                    <button class="nav-btn" id="nextBtn" aria-label="Próximo">
+                        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <polyline points="9,18 15,12 9,6"></polyline>
+                        </svg>
+                    </button>
+                </div>
             </div>
-            <div class="header-right">
-                <button class="nav-btn" id="prevBtn" aria-label="Anterior">
-                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                        <polyline points="15,18 9,12 15,6"></polyline>
-                    </svg>
-                </button>
-                <button class="nav-btn" id="nextBtn" aria-label="Próximo">
-                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                        <polyline points="9,18 15,12 9,6"></polyline>
-                    </svg>
-                </button>
-            </div>
+            <!-- Banner opcional: insira conteúdo dinâmico conforme necessário -->
+            <div class="dashboard-banner" id="dashboardBanner" aria-live="polite" aria-atomic="true"></div>
         </header>
 
         <!-- Filters Section -->

--- a/style.css
+++ b/style.css
@@ -1,83 +1,90 @@
 :root {
-  /* Primitive Color Tokens */
-  --color-white: rgba(255, 255, 255, 1);
-  --color-black: rgba(0, 0, 0, 1);
-  --color-cream-50: rgba(252, 252, 249, 1);
-  --color-cream-100: rgba(255, 255, 253, 1);
-  --color-gray-200: rgba(245, 245, 245, 1);
-  --color-gray-300: rgba(167, 169, 169, 1);
-  --color-gray-400: rgba(119, 124, 124, 1);
-  --color-slate-500: rgba(98, 108, 113, 1);
-  --color-brown-600: rgba(94, 82, 64, 1);
-  --color-charcoal-700: rgba(31, 33, 33, 1);
-  --color-charcoal-800: rgba(38, 40, 40, 1);
-  --color-slate-900: rgba(19, 52, 59, 1);
-  --color-teal-300: rgba(50, 184, 198, 1);
-  --color-teal-400: rgba(45, 166, 178, 1);
-  --color-teal-500: rgba(33, 128, 141, 1);
-  --color-teal-600: rgba(29, 116, 128, 1);
-  --color-teal-700: rgba(26, 104, 115, 1);
-  --color-teal-800: rgba(41, 150, 161, 1);
-  --color-red-400: rgba(255, 84, 89, 1);
-  --color-red-500: rgba(192, 21, 47, 1);
-  --color-orange-400: rgba(230, 129, 97, 1);
-  --color-orange-500: rgba(168, 75, 47, 1);
+  /* LIDER Solar Palette */
+  --color-white: #ffffff;
+  --color-black: #000000;
+  --color-ivory-50: #fff8f1;
+  --color-ivory-100: #fff1e6;
+  --color-ivory-200: #f7e3d4;
+  --color-blush-50: #fcebe6;
+  --color-blush-100: #f8d9d6;
+  --color-blush-200: #f1c4c9;
+  --color-honey-100: #f9e5c3;
+  --color-honey-200: #f2d3a6;
+  --color-terracotta-400: #af541f;
+  --color-terracotta-500: #a74b1a;
+  --color-terracotta-600: #8c3a14;
+  --color-rosewood-700: #6d2a0f;
+  --color-espresso-900: #3a1f1a;
+  --color-espresso-700: #6f4b3e;
+  --color-espresso-500: #8f6b5e;
+  --color-aurum-500: #be8621;
 
-  /* RGB versions for opacity control */
-  --color-brown-600-rgb: 94, 82, 64;
-  --color-teal-500-rgb: 33, 128, 141;
-  --color-slate-900-rgb: 19, 52, 59;
-  --color-slate-500-rgb: 98, 108, 113;
-  --color-red-500-rgb: 192, 21, 47;
-  --color-red-400-rgb: 255, 84, 89;
-  --color-orange-500-rgb: 168, 75, 47;
-  --color-orange-400-rgb: 230, 129, 97;
+  /* RGB tokens for opacity control */
+  --color-terracotta-400-rgb: 175, 84, 31;
+  --color-terracotta-500-rgb: 167, 75, 26;
+  --color-terracotta-600-rgb: 140, 58, 20;
+  --color-espresso-900-rgb: 58, 31, 26;
+  --color-espresso-700-rgb: 111, 75, 62;
+  --color-blush-200-rgb: 241, 196, 201;
+  --color-honey-200-rgb: 242, 211, 166;
+  --color-aurum-500-rgb: 190, 134, 33;
 
-  /* Background color tokens (Light Mode) */
-  --color-bg-1: rgba(59, 130, 246, 0.08); /* Light blue */
-  --color-bg-2: rgba(245, 158, 11, 0.08); /* Light yellow */
-  --color-bg-3: rgba(34, 197, 94, 0.08); /* Light green */
-  --color-bg-4: rgba(239, 68, 68, 0.08); /* Light red */
-  --color-bg-5: rgba(147, 51, 234, 0.08); /* Light purple */
-  --color-bg-6: rgba(249, 115, 22, 0.08); /* Light orange */
-  --color-bg-7: rgba(236, 72, 153, 0.08); /* Light pink */
-  --color-bg-8: rgba(6, 182, 212, 0.08); /* Light cyan */
+  /* Background accents (Light Mode) */
+  --color-bg-1: #fcebe2;
+  --color-bg-2: #f9e1d2;
+  --color-bg-3: #f5d4c4;
+  --color-bg-4: #f7d6c7;
+  --color-bg-5: #f3cfe0;
+  --color-bg-6: #f1d9b8;
+  --color-bg-7: #f5e0e8;
+  --color-bg-8: #f4d8c2;
 
   /* Semantic Color Tokens (Light Mode) */
-  --color-background: var(--color-cream-50);
-  --color-surface: var(--color-cream-100);
-  --color-text: var(--color-slate-900);
-  --color-text-secondary: var(--color-slate-500);
-  --color-primary: var(--color-teal-500);
-  --color-primary-hover: var(--color-teal-600);
-  --color-primary-active: var(--color-teal-700);
-  --color-secondary: rgba(var(--color-brown-600-rgb), 0.12);
-  --color-secondary-hover: rgba(var(--color-brown-600-rgb), 0.2);
-  --color-secondary-active: rgba(var(--color-brown-600-rgb), 0.25);
-  --color-border: rgba(var(--color-brown-600-rgb), 0.2);
-  --color-btn-primary-text: var(--color-cream-50);
-  --color-card-border: rgba(var(--color-brown-600-rgb), 0.12);
-  --color-card-border-inner: rgba(var(--color-brown-600-rgb), 0.12);
-  --color-error: var(--color-red-500);
-  --color-success: var(--color-teal-500);
-  --color-warning: var(--color-orange-500);
-  --color-info: var(--color-slate-500);
-  --color-focus-ring: rgba(var(--color-teal-500-rgb), 0.4);
-  --color-select-caret: rgba(var(--color-slate-900-rgb), 0.8);
+  --color-background: var(--color-ivory-50);
+  --color-surface: var(--color-ivory-100);
+  --color-text: var(--color-espresso-900);
+  --color-text-secondary: var(--color-espresso-700);
+  --color-primary: var(--color-terracotta-500);
+  --color-primary-hover: var(--color-terracotta-400);
+  --color-primary-active: var(--color-terracotta-600);
+  --color-secondary: rgba(var(--color-aurum-500-rgb), 0.18);
+  --color-secondary-hover: rgba(var(--color-aurum-500-rgb), 0.26);
+  --color-secondary-active: rgba(var(--color-aurum-500-rgb), 0.32);
+  --color-border: rgba(var(--color-espresso-700-rgb), 0.28);
+  --color-card-border: rgba(var(--color-espresso-700-rgb), 0.2);
+  --color-card-border-inner: rgba(var(--color-espresso-700-rgb), 0.16);
+  --color-btn-primary-text: var(--color-ivory-50);
+  --color-error: #c2303a;
+  --color-success: #5d7e1e;
+  --color-warning: var(--color-aurum-500);
+  --color-info: var(--color-espresso-500);
+  --color-focus-ring: rgba(var(--color-terracotta-400-rgb), 0.4);
+  --color-select-caret: rgba(var(--color-espresso-900-rgb), 0.8);
 
   /* Common style patterns */
   --focus-ring: 0 0 0 3px var(--color-focus-ring);
   --focus-outline: 2px solid var(--color-primary);
-  --status-bg-opacity: 0.15;
-  --status-border-opacity: 0.25;
-  --select-caret-light: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%23134252' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
-  --select-caret-dark: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%23f5f5f5' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
+  --status-bg-opacity: 0.18;
+  --status-border-opacity: 0.3;
+  --select-caret-light: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%236F4B3E' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
+  --select-caret-dark: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%23F6E7DD' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
 
   /* RGB versions for opacity control */
-  --color-success-rgb: 33, 128, 141;
-  --color-error-rgb: 192, 21, 47;
-  --color-warning-rgb: 168, 75, 47;
-  --color-info-rgb: 98, 108, 113;
+  --color-success-rgb: 93, 126, 30;
+  --color-error-rgb: 194, 48, 58;
+  --color-warning-rgb: 190, 134, 33;
+  --color-info-rgb: 143, 107, 94;
+
+  /* Banner styling tokens */
+  --banner-gradient-start: rgba(var(--color-terracotta-500-rgb), 0.2);
+  --banner-gradient-end: rgba(var(--color-aurum-500-rgb), 0.22);
+  --banner-image: none;
+  --banner-overlay: linear-gradient(
+    135deg,
+    var(--banner-gradient-start),
+    var(--banner-gradient-end)
+  );
+  --banner-text-color: var(--color-text);
 
   /* Typography */
   --font-family-base: "FKGroteskNeue", "Geist", "Inter", -apple-system,
@@ -123,14 +130,14 @@
   --radius-full: 9999px;
 
   /* Shadows */
-  --shadow-xs: 0 1px 2px rgba(0, 0, 0, 0.02);
-  --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.04), 0 1px 2px rgba(0, 0, 0, 0.02);
-  --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.04),
-    0 2px 4px -1px rgba(0, 0, 0, 0.02);
-  --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.04),
-    0 4px 6px -2px rgba(0, 0, 0, 0.02);
-  --shadow-inset-sm: inset 0 1px 0 rgba(255, 255, 255, 0.15),
-    inset 0 -1px 0 rgba(0, 0, 0, 0.03);
+  --shadow-xs: 0 1px 2px rgba(0, 0, 0, 0.03);
+  --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.05), 0 1px 2px rgba(0, 0, 0, 0.03);
+  --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.05),
+    0 2px 4px -1px rgba(0, 0, 0, 0.03);
+  --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.06),
+    0 4px 6px -2px rgba(0, 0, 0, 0.04);
+  --shadow-inset-sm: inset 0 1px 0 rgba(255, 255, 255, 0.2),
+    inset 0 -1px 0 rgba(0, 0, 0, 0.04);
 
   /* Animation */
   --duration-fast: 150ms;
@@ -147,154 +154,135 @@
 /* Dark mode colors */
 @media (prefers-color-scheme: dark) {
   :root {
-    /* RGB versions for opacity control (Dark Mode) */
-    --color-gray-400-rgb: 119, 124, 124;
-    --color-teal-300-rgb: 50, 184, 198;
-    --color-gray-300-rgb: 167, 169, 169;
-    --color-gray-200-rgb: 245, 245, 245;
-
-    /* Background color tokens (Dark Mode) */
-    --color-bg-1: rgba(29, 78, 216, 0.15); /* Dark blue */
-    --color-bg-2: rgba(180, 83, 9, 0.15); /* Dark yellow */
-    --color-bg-3: rgba(21, 128, 61, 0.15); /* Dark green */
-    --color-bg-4: rgba(185, 28, 28, 0.15); /* Dark red */
-    --color-bg-5: rgba(107, 33, 168, 0.15); /* Dark purple */
-    --color-bg-6: rgba(194, 65, 12, 0.15); /* Dark orange */
-    --color-bg-7: rgba(190, 24, 93, 0.15); /* Dark pink */
-    --color-bg-8: rgba(8, 145, 178, 0.15); /* Dark cyan */
+    /* Warm dark theme tokens */
+    --color-bg-1: rgba(242, 166, 90, 0.18);
+    --color-bg-2: rgba(248, 217, 205, 0.18);
+    --color-bg-3: rgba(217, 122, 84, 0.16);
+    --color-bg-4: rgba(244, 108, 127, 0.2);
+    --color-bg-5: rgba(206, 128, 173, 0.22);
+    --color-bg-6: rgba(244, 196, 120, 0.2);
+    --color-bg-7: rgba(222, 168, 189, 0.22);
+    --color-bg-8: rgba(240, 177, 142, 0.22);
 
     /* Semantic Color Tokens (Dark Mode) */
-    --color-background: var(--color-charcoal-700);
-    --color-surface: var(--color-charcoal-800);
-    --color-text: var(--color-gray-200);
-    --color-text-secondary: rgba(var(--color-gray-300-rgb), 0.7);
-    --color-primary: var(--color-teal-300);
-    --color-primary-hover: var(--color-teal-400);
-    --color-primary-active: var(--color-teal-800);
-    --color-secondary: rgba(var(--color-gray-400-rgb), 0.15);
-    --color-secondary-hover: rgba(var(--color-gray-400-rgb), 0.25);
-    --color-secondary-active: rgba(var(--color-gray-400-rgb), 0.3);
-    --color-border: rgba(var(--color-gray-400-rgb), 0.3);
-    --color-error: var(--color-red-400);
-    --color-success: var(--color-teal-300);
-    --color-warning: var(--color-orange-400);
-    --color-info: var(--color-gray-300);
-    --color-focus-ring: rgba(var(--color-teal-300-rgb), 0.4);
-    --color-btn-primary-text: var(--color-slate-900);
-    --color-card-border: rgba(var(--color-gray-400-rgb), 0.2);
-    --color-card-border-inner: rgba(var(--color-gray-400-rgb), 0.15);
-    --shadow-inset-sm: inset 0 1px 0 rgba(255, 255, 255, 0.1),
-      inset 0 -1px 0 rgba(0, 0, 0, 0.15);
-    --button-border-secondary: rgba(var(--color-gray-400-rgb), 0.2);
-    --color-border-secondary: rgba(var(--color-gray-400-rgb), 0.2);
-    --color-select-caret: rgba(var(--color-gray-200-rgb), 0.8);
+    --color-background: #1d130f;
+    --color-surface: #251713;
+    --color-text: #fbeee6;
+    --color-text-secondary: rgba(248, 217, 205, 0.76);
+    --color-primary: #f2a65a;
+    --color-primary-hover: #ffb96f;
+    --color-primary-active: #e08538;
+    --color-secondary: rgba(248, 217, 205, 0.18);
+    --color-secondary-hover: rgba(248, 217, 205, 0.26);
+    --color-secondary-active: rgba(248, 217, 205, 0.32);
+    --color-border: rgba(242, 166, 90, 0.32);
+    --color-btn-primary-text: #2b1108;
+    --color-card-border: rgba(242, 166, 90, 0.24);
+    --color-card-border-inner: rgba(242, 166, 90, 0.18);
+    --color-error: #f46c7f;
+    --color-success: #b7db72;
+    --color-warning: #ffc36b;
+    --color-info: #f0b3a8;
+    --color-focus-ring: rgba(242, 166, 90, 0.3);
+    --color-border-secondary: rgba(248, 217, 205, 0.24);
+    --color-select-caret: rgba(251, 237, 229, 0.9);
+    --shadow-inset-sm: inset 0 1px 0 rgba(255, 255, 255, 0.08),
+      inset 0 -1px 0 rgba(0, 0, 0, 0.3);
 
     /* Common style patterns - updated for dark mode */
     --focus-ring: 0 0 0 3px var(--color-focus-ring);
     --focus-outline: 2px solid var(--color-primary);
-    --status-bg-opacity: 0.15;
-    --status-border-opacity: 0.25;
-    --select-caret-light: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%23134252' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
-    --select-caret-dark: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%23f5f5f5' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
+    --status-bg-opacity: 0.2;
+    --status-border-opacity: 0.35;
 
     /* RGB versions for dark mode */
-    --color-success-rgb: var(--color-teal-300-rgb);
-    --color-error-rgb: var(--color-red-400-rgb);
-    --color-warning-rgb: var(--color-orange-400-rgb);
-    --color-info-rgb: var(--color-gray-300-rgb);
+    --color-success-rgb: 183, 219, 114;
+    --color-error-rgb: 244, 108, 127;
+    --color-warning-rgb: 255, 195, 107;
+    --color-info-rgb: 240, 179, 168;
   }
 }
 
 /* Data attribute for manual theme switching */
 [data-color-scheme="dark"] {
-  /* RGB versions for opacity control (dark mode) */
-  --color-gray-400-rgb: 119, 124, 124;
-  --color-teal-300-rgb: 50, 184, 198;
-  --color-gray-300-rgb: 167, 169, 169;
-  --color-gray-200-rgb: 245, 245, 245;
-
-  /* Colorful background palette - Dark Mode */
-  --color-bg-1: rgba(29, 78, 216, 0.15); /* Dark blue */
-  --color-bg-2: rgba(180, 83, 9, 0.15); /* Dark yellow */
-  --color-bg-3: rgba(21, 128, 61, 0.15); /* Dark green */
-  --color-bg-4: rgba(185, 28, 28, 0.15); /* Dark red */
-  --color-bg-5: rgba(107, 33, 168, 0.15); /* Dark purple */
-  --color-bg-6: rgba(194, 65, 12, 0.15); /* Dark orange */
-  --color-bg-7: rgba(190, 24, 93, 0.15); /* Dark pink */
-  --color-bg-8: rgba(8, 145, 178, 0.15); /* Dark cyan */
-
-  /* Semantic Color Tokens (Dark Mode) */
-  --color-background: var(--color-charcoal-700);
-  --color-surface: var(--color-charcoal-800);
-  --color-text: var(--color-gray-200);
-  --color-text-secondary: rgba(var(--color-gray-300-rgb), 0.7);
-  --color-primary: var(--color-teal-300);
-  --color-primary-hover: var(--color-teal-400);
-  --color-primary-active: var(--color-teal-800);
-  --color-secondary: rgba(var(--color-gray-400-rgb), 0.15);
-  --color-secondary-hover: rgba(var(--color-gray-400-rgb), 0.25);
-  --color-secondary-active: rgba(var(--color-gray-400-rgb), 0.3);
-  --color-border: rgba(var(--color-gray-400-rgb), 0.3);
-  --color-error: var(--color-red-400);
-  --color-success: var(--color-teal-300);
-  --color-warning: var(--color-orange-400);
-  --color-info: var(--color-gray-300);
-  --color-focus-ring: rgba(var(--color-teal-300-rgb), 0.4);
-  --color-btn-primary-text: var(--color-slate-900);
-  --color-card-border: rgba(var(--color-gray-400-rgb), 0.15);
-  --color-card-border-inner: rgba(var(--color-gray-400-rgb), 0.15);
-  --shadow-inset-sm: inset 0 1px 0 rgba(255, 255, 255, 0.1),
-    inset 0 -1px 0 rgba(0, 0, 0, 0.15);
-  --color-border-secondary: rgba(var(--color-gray-400-rgb), 0.2);
-  --color-select-caret: rgba(var(--color-gray-200-rgb), 0.8);
-
-  /* Common style patterns - updated for dark mode */
+  --color-bg-1: rgba(242, 166, 90, 0.18);
+  --color-bg-2: rgba(248, 217, 205, 0.18);
+  --color-bg-3: rgba(217, 122, 84, 0.16);
+  --color-bg-4: rgba(244, 108, 127, 0.2);
+  --color-bg-5: rgba(206, 128, 173, 0.22);
+  --color-bg-6: rgba(244, 196, 120, 0.2);
+  --color-bg-7: rgba(222, 168, 189, 0.22);
+  --color-bg-8: rgba(240, 177, 142, 0.22);
+  --color-background: #1d130f;
+  --color-surface: #251713;
+  --color-text: #fbeee6;
+  --color-text-secondary: rgba(248, 217, 205, 0.76);
+  --color-primary: #f2a65a;
+  --color-primary-hover: #ffb96f;
+  --color-primary-active: #e08538;
+  --color-secondary: rgba(248, 217, 205, 0.18);
+  --color-secondary-hover: rgba(248, 217, 205, 0.26);
+  --color-secondary-active: rgba(248, 217, 205, 0.32);
+  --color-border: rgba(242, 166, 90, 0.32);
+  --color-btn-primary-text: #2b1108;
+  --color-card-border: rgba(242, 166, 90, 0.24);
+  --color-card-border-inner: rgba(242, 166, 90, 0.18);
+  --color-error: #f46c7f;
+  --color-success: #b7db72;
+  --color-warning: #ffc36b;
+  --color-info: #f0b3a8;
+  --color-focus-ring: rgba(242, 166, 90, 0.3);
+  --color-border-secondary: rgba(248, 217, 205, 0.24);
+  --color-select-caret: rgba(251, 237, 229, 0.9);
+  --shadow-inset-sm: inset 0 1px 0 rgba(255, 255, 255, 0.08),
+    inset 0 -1px 0 rgba(0, 0, 0, 0.3);
   --focus-ring: 0 0 0 3px var(--color-focus-ring);
   --focus-outline: 2px solid var(--color-primary);
-  --status-bg-opacity: 0.15;
-  --status-border-opacity: 0.25;
-  --select-caret-light: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%23134252' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
-  --select-caret-dark: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%23f5f5f5' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
-
-  /* RGB versions for dark mode */
-  --color-success-rgb: var(--color-teal-300-rgb);
-  --color-error-rgb: var(--color-red-400-rgb);
-  --color-warning-rgb: var(--color-orange-400-rgb);
-  --color-info-rgb: var(--color-gray-300-rgb);
+  --status-bg-opacity: 0.2;
+  --status-border-opacity: 0.35;
+  --color-success-rgb: 183, 219, 114;
+  --color-error-rgb: 244, 108, 127;
+  --color-warning-rgb: 255, 195, 107;
+  --color-info-rgb: 240, 179, 168;
 }
 
 [data-color-scheme="light"] {
-  /* RGB versions for opacity control (light mode) */
-  --color-brown-600-rgb: 94, 82, 64;
-  --color-teal-500-rgb: 33, 128, 141;
-  --color-slate-900-rgb: 19, 52, 59;
-
-  /* Semantic Color Tokens (Light Mode) */
-  --color-background: var(--color-cream-50);
-  --color-surface: var(--color-cream-100);
-  --color-text: var(--color-slate-900);
-  --color-text-secondary: var(--color-slate-500);
-  --color-primary: var(--color-teal-500);
-  --color-primary-hover: var(--color-teal-600);
-  --color-primary-active: var(--color-teal-700);
-  --color-secondary: rgba(var(--color-brown-600-rgb), 0.12);
-  --color-secondary-hover: rgba(var(--color-brown-600-rgb), 0.2);
-  --color-secondary-active: rgba(var(--color-brown-600-rgb), 0.25);
-  --color-border: rgba(var(--color-brown-600-rgb), 0.2);
-  --color-btn-primary-text: var(--color-cream-50);
-  --color-card-border: rgba(var(--color-brown-600-rgb), 0.12);
-  --color-card-border-inner: rgba(var(--color-brown-600-rgb), 0.12);
-  --color-error: var(--color-red-500);
-  --color-success: var(--color-teal-500);
-  --color-warning: var(--color-orange-500);
-  --color-info: var(--color-slate-500);
-  --color-focus-ring: rgba(var(--color-teal-500-rgb), 0.4);
-
-  /* RGB versions for light mode */
-  --color-success-rgb: var(--color-teal-500-rgb);
-  --color-error-rgb: var(--color-red-500-rgb);
-  --color-warning-rgb: var(--color-orange-500-rgb);
-  --color-info-rgb: var(--color-slate-500-rgb);
+  --color-bg-1: #fcebe2;
+  --color-bg-2: #f9e1d2;
+  --color-bg-3: #f5d4c4;
+  --color-bg-4: #f7d6c7;
+  --color-bg-5: #f3cfe0;
+  --color-bg-6: #f1d9b8;
+  --color-bg-7: #f5e0e8;
+  --color-bg-8: #f4d8c2;
+  --color-background: var(--color-ivory-50);
+  --color-surface: var(--color-ivory-100);
+  --color-text: var(--color-espresso-900);
+  --color-text-secondary: var(--color-espresso-700);
+  --color-primary: var(--color-terracotta-500);
+  --color-primary-hover: var(--color-terracotta-400);
+  --color-primary-active: var(--color-terracotta-600);
+  --color-secondary: rgba(var(--color-aurum-500-rgb), 0.18);
+  --color-secondary-hover: rgba(var(--color-aurum-500-rgb), 0.26);
+  --color-secondary-active: rgba(var(--color-aurum-500-rgb), 0.32);
+  --color-border: rgba(var(--color-espresso-700-rgb), 0.28);
+  --color-btn-primary-text: var(--color-ivory-50);
+  --color-card-border: rgba(var(--color-espresso-700-rgb), 0.2);
+  --color-card-border-inner: rgba(var(--color-espresso-700-rgb), 0.16);
+  --color-error: #c2303a;
+  --color-success: #5d7e1e;
+  --color-warning: var(--color-aurum-500);
+  --color-info: var(--color-espresso-500);
+  --color-focus-ring: rgba(var(--color-terracotta-400-rgb), 0.4);
+  --color-select-caret: rgba(var(--color-espresso-900-rgb), 0.8);
+  --focus-ring: 0 0 0 3px var(--color-focus-ring);
+  --focus-outline: 2px solid var(--color-primary);
+  --status-bg-opacity: 0.18;
+  --status-border-opacity: 0.3;
+  --color-success-rgb: 93, 126, 30;
+  --color-error-rgb: 194, 48, 58;
+  --color-warning-rgb: 190, 134, 33;
+  --color-info-rgb: 143, 107, 94;
 }
 
 /* Base styles */
@@ -750,18 +738,27 @@ select.form-control {
   border-bottom: 1px solid var(--color-border);
   padding: var(--space-16) var(--space-24);
   display: flex;
-  justify-content: space-between;
-  align-items: center;
+  flex-direction: column;
+  gap: var(--space-16);
   position: sticky;
   top: 0;
   z-index: 100;
   box-shadow: var(--shadow-sm);
 }
 
+.dashboard-header__top {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--space-16);
+}
+
 .header-left {
   display: flex;
   align-items: center;
   gap: var(--space-16);
+  flex-wrap: wrap;
 }
 
 .header-left h1 {
@@ -785,6 +782,41 @@ select.form-control {
   gap: var(--space-8);
 }
 
+/*
+  Banner customization
+  - Update the graphic via the --banner-image variable (e.g. `.dashboard-banner { --banner-image: url("/path.jpg"); }`).
+  - Adjust --banner-gradient-start and --banner-gradient-end to fine-tune the warm overlay and keep AA contrast over photography.
+  - If the artwork demands a different copy color, override --banner-text-color.
+  - Remove the content or add the `.is-hidden` helper class to collapse the banner region.
+*/
+.dashboard-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: var(--space-16);
+  width: 100%;
+  padding: var(--space-16) var(--space-20);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--color-card-border);
+  background-color: transparent;
+  background-image: var(--banner-overlay), var(--banner-image);
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
+  box-shadow: var(--shadow-sm);
+  color: var(--banner-text-color);
+  position: relative;
+  overflow: hidden;
+  min-height: 72px;
+  text-align: left;
+}
+
+.dashboard-banner:empty,
+.dashboard-banner.is-hidden {
+  display: none;
+}
+
 .nav-btn {
   background-color: var(--color-secondary);
   border: 1px solid var(--color-border);
@@ -804,6 +836,7 @@ select.form-control {
 }
 
 .nav-btn:active {
+  background-color: var(--color-secondary-active);
   transform: translateY(0);
 }
 
@@ -1312,18 +1345,34 @@ select.form-control {
 @media (max-width: 768px) {
   .dashboard-header {
     padding: var(--space-16);
+    gap: var(--space-12);
+  }
+
+  .dashboard-header__top {
     flex-direction: column;
+    align-items: stretch;
     gap: var(--space-12);
   }
 
   .header-left {
     flex-direction: column;
     gap: var(--space-8);
-    text-align: center;
+    align-items: flex-start;
+    text-align: left;
   }
 
   .header-left h1 {
     font-size: var(--font-size-xl);
+  }
+
+  .header-right {
+    justify-content: flex-start;
+  }
+
+  .dashboard-banner {
+    padding: var(--space-16);
+    flex-direction: column;
+    align-items: flex-start;
   }
 
   .filters-container {


### PR DESCRIPTION
## Summary
- redefine tokens de cor para uma paleta solar/rosé alinhada à identidade da LIDER e aplica aos componentes principais com estados hover/focus acessíveis
- adiciona variáveis e documentação para personalizar o banner e demais elementos com a nova paleta
- inclui região opcional de banner no header com estilos responsivos e comportamento oculto quando vazio

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68c9d80a670883219364ad7a264d2d95