### PR TITLE
Calcula IC automaticamente a partir dos preços

### DIFF
--- a/index.html
+++ b/index.html
@@ -104,12 +104,12 @@
                                     <p class="price promotional" data-value="7500" id="otimaPrecoPromocional">R$ 7.500,00</p>
                                 </div>
                                 <div class="info-card">
-                                    <h3>IC de % Tabela</h3>
-                                    <p class="percentage" data-value="95" id="otimaPercentualTabela">95%</p>
+                                    <h3>IC REGULAR</h3>
+                                    <p class="percentage" id="otimaIcRegular">—</p>
                                 </div>
                                 <div class="info-card">
-                                    <h3>IC de % Promocional</h3>
-                                    <p class="percentage" data-value="30" id="otimaPercentualPromocional">30%</p>
+                                    <h3>IC PROMOCIONAL</h3>
+                                    <p class="percentage" id="otimaIcPromocional">—</p>
                                 </div>
                             </div>
                         </div>
@@ -138,12 +138,12 @@
                                     <p class="price promotional" data-value="9250" id="concorrentePrecoPromocional">R$ 9.250,00</p>
                                 </div>
                                 <div class="info-card">
-                                    <h3>IC de % Tabela</h3>
-                                    <p class="percentage" data-value="90" id="concorrentePercentualTabela">90%</p>
+                                    <h3>IC REGULAR</h3>
+                                    <p class="percentage" id="concorrenteIcRegular">—</p>
                                 </div>
                                 <div class="info-card">
-                                    <h3>IC de % Promocional</h3>
-                                    <p class="percentage" data-value="95" id="concorrentePercentualPromocional">95%</p>
+                                    <h3>IC PROMOCIONAL</h3>
+                                    <p class="percentage" id="concorrenteIcPromocional">—</p>
                                 </div>
                             </div>
                         </div>
@@ -275,14 +275,14 @@
                                 <input type="number" id="modalOtimaPrecoPromocional" class="form-control" step="0.01" required placeholder="0,00">
                             </div>
                             <div class="form-group">
-                                <label for="modalOtimaPercentualTabela" class="form-label">IC de % Tabela *</label>
-                                <input type="number" id="modalOtimaPercentualTabela" class="form-control" min="0" max="100" required placeholder="0">
+                                <label class="form-label">IC REGULAR</label>
+                                <p class="form-static" id="modalOtimaIcRegular">—</p>
                             </div>
                         </div>
                         <div class="form-row">
                             <div class="form-group">
-                                <label for="modalOtimaPercentualPromocional" class="form-label">IC de % Promocional *</label>
-                                <input type="number" id="modalOtimaPercentualPromocional" class="form-control" min="0" max="100" required placeholder="0">
+                                <label class="form-label">IC PROMOCIONAL</label>
+                                <p class="form-static" id="modalOtimaIcPromocional">—</p>
                             </div>
                         </div>
                     </div>
@@ -318,14 +318,14 @@
                                 <input type="number" id="modalConcorrentePrecoPromocional" class="form-control" step="0.01" required placeholder="0,00">
                             </div>
                             <div class="form-group">
-                                <label for="modalConcorrentePercentualTabela" class="form-label">IC de % Tabela *</label>
-                                <input type="number" id="modalConcorrentePercentualTabela" class="form-control" min="0" max="100" required placeholder="0">
+                                <label class="form-label">IC REGULAR</label>
+                                <p class="form-static" id="modalConcorrenteIcRegular">—</p>
                             </div>
                         </div>
                         <div class="form-row">
                             <div class="form-group">
-                                <label for="modalConcorrentePercentualPromocional" class="form-label">IC de % Promocional *</label>
-                                <input type="number" id="modalConcorrentePercentualPromocional" class="form-control" min="0" max="100" required placeholder="0">
+                                <label class="form-label">IC PROMOCIONAL</label>
+                                <p class="form-static" id="modalConcorrenteIcPromocional">—</p>
                             </div>
                             <div class="form-group">
                                 <label for="modalDiffPesquisa" class="form-label">Diferença de Pesquisa (%) *</label>

--- a/style.css
+++ b/style.css
@@ -521,6 +521,26 @@ select.form-control {
   margin-bottom: var(--space-16);
 }
 
+.form-static {
+  padding: var(--space-8) var(--space-12);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-base);
+  background-color: rgba(var(--color-espresso-700-rgb), 0.06);
+  min-height: 44px;
+  display: flex;
+  align-items: center;
+  font-size: var(--font-size-base);
+  color: var(--color-text-secondary);
+}
+
+@media (prefers-color-scheme: dark) {
+  .form-static {
+    border-color: var(--color-border-secondary, var(--color-border));
+    background-color: rgba(var(--color-border-secondary-rgb, 248, 217, 205), 0.14);
+    color: var(--color-text);
+  }
+}
+
 /* Card component */
 .card {
   background-color: var(--color-surface);


### PR DESCRIPTION
## Resumo
- Renomeia os indicadores para “IC REGULAR” e “IC PROMOCIONAL”, além de mostrar os valores calculados automaticamente no modal de cadastro.
- Calcula o IC a partir dos preços informados, exibindo e exportando os valores formatados com casa decimal e tratando ausência de preço do concorrente.
- Ajusta o estilo dos campos informativos do modal para refletir o novo comportamento somente leitura.

## Testes
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68c9e0da5b24832197d7668dbe764dac