### PR TITLE
Atualiza cálculo de descontos e exibição no dashboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -111,6 +111,12 @@
                                     <h3>IC PROMOCIONAL</h3>
                                     <p class="percentage" id="otimaIcPromocional">—</p>
                                 </div>
+                                <div class="info-card">
+                                    <h3>Desconto Política</h3>
+                                    <p class="percentage">
+                                        <span class="discount-indicator" id="otimaDescontoPolitica">—</span>
+                                    </p>
+                                </div>
                             </div>
                         </div>
                     </div>
@@ -145,6 +151,12 @@
                                     <h3>IC PROMOCIONAL</h3>
                                     <p class="percentage" id="concorrenteIcPromocional">—</p>
                                 </div>
+                                <div class="info-card">
+                                    <h3>Desconto Concorrente</h3>
+                                    <p class="percentage">
+                                        <span class="discount-indicator" id="concorrenteDesconto">—</span>
+                                    </p>
+                                </div>
                             </div>
                         </div>
                     </div>
@@ -178,7 +190,8 @@
                                 <th>Localização</th>
                                 <th>Produto Lider</th>
                                 <th>Concorrente</th>
-                                <th>Diff Pesquisa</th>
+                                <th>Desconto Política</th>
+                                <th>Desconto Concorrente</th>
                                 <th>Pesquisador</th>
                                 <th>Record</th>
                                 <th>Ações</th>
@@ -285,6 +298,14 @@
                                 <p class="form-static" id="modalOtimaIcPromocional">—</p>
                             </div>
                         </div>
+                        <div class="form-row">
+                            <div class="form-group">
+                                <label class="form-label">Desconto Política</label>
+                                <p class="form-static">
+                                    <span class="discount-indicator" id="modalOtimaDescontoPolitica">—</span>
+                                </p>
+                            </div>
+                        </div>
                     </div>
 
                     <!-- Produto Concorrente -->
@@ -328,8 +349,10 @@
                                 <p class="form-static" id="modalConcorrenteIcPromocional">—</p>
                             </div>
                             <div class="form-group">
-                                <label for="modalDiffPesquisa" class="form-label">Diferença de Pesquisa (%) *</label>
-                                <input type="number" id="modalDiffPesquisa" class="form-control" required placeholder="0">
+                                <label class="form-label">Desconto Concorrente</label>
+                                <p class="form-static">
+                                    <span class="discount-indicator" id="modalConcorrenteDesconto">—</span>
+                                </p>
                             </div>
                         </div>
                     </div>

--- a/style.css
+++ b/style.css
@@ -1100,14 +1100,66 @@ select.form-control {
   border-bottom: none;
 }
 
-.diff-positive {
-  color: var(--color-success);
+.discount-indicator {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 72px;
+  padding: var(--space-4) var(--space-10);
+  border-radius: 999px;
+  font-size: var(--font-size-sm);
   font-weight: var(--font-weight-medium);
+  line-height: 1.2;
+  background-color: rgba(var(--color-info-rgb), 0.12);
+  color: var(--color-info);
+  letter-spacing: 0.3px;
 }
 
-.diff-negative {
+.discount-indicator.discount-high {
+  background-color: rgba(var(--color-success-rgb), 0.2);
+  color: var(--color-success);
+}
+
+.discount-indicator.discount-medium {
+  background-color: rgba(var(--color-warning-rgb), 0.2);
+  color: var(--color-warning);
+}
+
+.discount-indicator.discount-low {
+  background-color: rgba(var(--color-error-rgb), 0.18);
   color: var(--color-error);
-  font-weight: var(--font-weight-medium);
+}
+
+.discount-indicator.discount-neutral {
+  background-color: rgba(var(--color-info-rgb), 0.14);
+  color: var(--color-info);
+}
+
+@media (prefers-color-scheme: dark) {
+  .discount-indicator {
+    background-color: rgba(var(--color-info-rgb), 0.22);
+    color: var(--color-ivory-100);
+  }
+
+  .discount-indicator.discount-high {
+    background-color: rgba(var(--color-success-rgb), 0.28);
+    color: var(--color-ivory-100);
+  }
+
+  .discount-indicator.discount-medium {
+    background-color: rgba(var(--color-warning-rgb), 0.28);
+    color: var(--color-ivory-100);
+  }
+
+  .discount-indicator.discount-low {
+    background-color: rgba(var(--color-error-rgb), 0.26);
+    color: var(--color-ivory-100);
+  }
+
+  .discount-indicator.discount-neutral {
+    background-color: rgba(var(--color-info-rgb), 0.26);
+    color: var(--color-ivory-100);
+  }
 }
 
 /* Modal Styles */


### PR DESCRIPTION
## Summary
- substitui o campo de diferença de pesquisa por descontos automáticos para Lider e Concorrente
- exibe os novos descontos nos cards, tabela e exportações com indicadores visuais coloridos
- ajusta o modal de cadastro para calcular e mostrar os descontos derivados, removendo a entrada manual

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68caad64c1d883219dcda9c588e9ef70