### PR TITLE
Add CSV import workflow

### DIFF
--- a/index.html
+++ b/index.html
@@ -174,6 +174,14 @@
                         </svg>
                         Exportar Dados
                     </button>
+                    <label for="importInput" class="btn btn--outline" id="importBtn" title="O arquivo CSV deve conter as colunas: Linha de Receita/Tipo, Mês, Ano, Localização, Produto Líder, Preço Tabela Líder, Preço Promocional Líder, Concorrente, Preço Tabela Concorrente, Preço Promocional Concorrente, Pesquisador e Record.">
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <path d="M4 4h16v16H4z"></path>
+                            <polyline points="8,12 11,15 16,9"></polyline>
+                        </svg>
+                        Importar CSV
+                    </label>
+                    <input type="file" id="importInput" accept=".csv" hidden>
                     <span class="export-info" id="exportInfo">0 itens exportáveis</span>
                 </div>
             </section>


### PR DESCRIPTION
## Summary
- add an Importar CSV control with tooltip guidance next to the export actions
- implement CSV parsing, validation, and product conversion utilities with discount recalculation before persisting
- update persistence, filtering helpers, status messaging, and wire the new handleImport routine into the dashboard lifecycle

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68cab23a1d9c8321a9c335d0b002d2fd