### PR TITLE
Add password-protected deletion workflow

### DIFF
--- a/index.html
+++ b/index.html
@@ -406,6 +406,36 @@
         </div>
     </div>
 
+    <!-- Modal de Exclusão -->
+    <div class="modal hidden" id="deleteModal">
+        <div class="modal-backdrop"></div>
+        <div class="modal-content modal-sm">
+            <div class="modal-header">
+                <h2>Excluir Item</h2>
+                <button class="modal-close" id="deleteModalCloseBtn" aria-label="Fechar">
+                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <line x1="18" y1="6" x2="6" y2="18"></line>
+                        <line x1="6" y1="6" x2="18" y2="18"></line>
+                    </svg>
+                </button>
+            </div>
+            <div class="modal-body">
+                <form id="deleteConfirmForm" class="delete-modal__form">
+                    <p class="delete-modal__description">
+                        Tem certeza de que deseja excluir este item? Essa ação não poderá ser desfeita.
+                    </p>
+                    <label for="deletePasswordInput" class="form-label">Senha de confirmação</label>
+                    <input type="password" id="deletePasswordInput" class="form-control" placeholder="Digite a senha de exclusão" autocomplete="current-password" required>
+                    <p class="form-feedback" id="deletePasswordError" aria-live="assertive"></p>
+                </form>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn--outline" id="deleteModalCancelBtn">Cancelar</button>
+                <button type="submit" form="deleteConfirmForm" class="btn btn--danger" id="deleteModalConfirmBtn">Excluir Item</button>
+            </div>
+        </div>
+    </div>
+
     <script src="app.js"></script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -60,6 +60,10 @@
   --color-info: var(--color-espresso-500);
   --color-focus-ring: rgba(var(--color-terracotta-400-rgb), 0.4);
   --color-select-caret: rgba(var(--color-espresso-900-rgb), 0.8);
+  --color-danger: var(--color-error);
+  --color-danger-surface: rgba(var(--color-error-rgb), 0.16);
+  --color-danger-surface-hover: rgba(var(--color-error-rgb), 0.24);
+  --color-danger-surface-active: rgba(var(--color-error-rgb), 0.32);
 
   /* Common style patterns */
   --focus-ring: 0 0 0 3px var(--color-focus-ring);
@@ -436,6 +440,19 @@ pre code {
   background: var(--color-secondary);
 }
 
+.btn--danger {
+  background: var(--color-danger-surface);
+  color: var(--color-danger);
+}
+
+.btn--danger:hover {
+  background: var(--color-danger-surface-hover);
+}
+
+.btn--danger:active {
+  background: var(--color-danger-surface-active);
+}
+
 .btn--sm {
   padding: var(--space-4) var(--space-12);
   font-size: var(--font-size-sm);
@@ -508,6 +525,29 @@ select.form-control {
 .form-control:focus {
   border-color: var(--color-primary);
   outline: var(--focus-outline);
+}
+
+.form-feedback {
+  margin-top: var(--space-4);
+  font-size: var(--font-size-sm);
+  color: var(--color-danger);
+  display: none;
+}
+
+.form-feedback.is-visible {
+  display: block;
+}
+
+.delete-modal__form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-12);
+}
+
+.delete-modal__description {
+  margin: 0;
+  color: var(--color-text-secondary);
+  line-height: var(--line-height-normal);
 }
 
 .form-label {
@@ -1092,6 +1132,13 @@ select.form-control {
   font-size: var(--font-size-base);
 }
 
+.table-actions {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: var(--space-8);
+  align-items: center;
+}
+
 .comparison-table tr:hover {
   background-color: var(--color-bg-5);
 }
@@ -1204,7 +1251,8 @@ select.form-control {
   flex-direction: column;
 }
 
-.modal-sm .modal-content {
+.modal-sm .modal-content,
+.modal-content.modal-sm {
   max-width: 400px;
 }
 


### PR DESCRIPTION
## Summary
- add a configurable password constant and modal helpers to support protected deletions, including body scroll handling
- expose an Excluir action in the comparison table and confirm removal through a password form before purging local data and filters
- extend the design system with danger button styling, feedback messaging, and layout rules for the new delete modal

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68c9d28f89bc8321a08f9146b23e574c